### PR TITLE
Fix the time of the CBS meetings, they actually happen at 14:00 UTC

### DIFF
--- a/meetings/cbs-infra.yaml
+++ b/meetings/cbs-infra.yaml
@@ -1,7 +1,7 @@
 project: Community Buildsystem & Infrastructure Meeting
 project_url: http://wiki.centos.org/HowTos/CommunityBuildSystem
 schedule:
-    - time:      '1700'
+    - time:      '1400'
       day:       Monday
       irc:       centos-devel
       frequency: biweekly-even


### PR DESCRIPTION
I accidentally typo'd the time for the CBS meeting. This PR fixes that.
