### PR TITLE
Change to weekly CBS meetings

### DIFF
--- a/meetings/cbs-infra.yaml
+++ b/meetings/cbs-infra.yaml
@@ -4,7 +4,7 @@ schedule:
     - time:      '1400'
       day:       Monday
       irc:       centos-devel
-      frequency: biweekly-even
+      frequency: weekly
 chair: Brian Stinson (bstinson), Fabian Arrotin (Arrfab), Karanbir Singh (kbsingh), Thomas Oulevey (alphacc)
 description: >
     The CBS/Infra meeting is for discussing and coordinating operations in the


### PR DESCRIPTION
We'll be using the CBS meeting time to go over and clear the backlog of SIG membership sponsorship requests. Let's get this on the calendar for every week.
