### PR TITLE
Revert "DST change for the Config Management SIG meetings"

### DIFF
--- a/meetings/config-management-sig.yaml
+++ b/meetings/config-management-sig.yaml
@@ -2,7 +2,7 @@ project: Config Management SIG
 project_url: https://wiki.centos.org/SpecialInterestGroup/ConfigManagementSIG
 meeting_id: Config Management SIG regular meeting
 schedule:
-  - time:       '1500'
+  - time:       '1600'
     day:        Wednesday
     irc:        centos-devel
     frequency:  biweekly-odd


### PR DESCRIPTION
Reverts CentOS/Calendar#15

Spoke to soon.  This meeting now conflicts with the paas-sig.
