### PR TITLE
Change time to 13:00 UTC Tue for SCLo SIG

### DIFF
--- a/meetings/software-collections-sig-sync-up.yaml
+++ b/meetings/software-collections-sig-sync-up.yaml
@@ -2,8 +2,8 @@ project:  Software Collections SIG Sync-up
 project_url: http://wiki.centos.org/SpecialInterestGroup/SCLo
 meeting_id: SCLo SIG sync-up meeting
 schedule:
-  - time:       '1600'
-    day:        Wednesday
+  - time:       '1300'
+    day:        Tuesday
     irc:        centos-devel
     frequency:  biweekly-even
 chair:  Honza Horak (hhorak)


### PR DESCRIPTION
Change time to 13:00 UTC for SCLo SIG, based on https://lists.centos.org/pipermail/centos-devel/2016-May/014743.html
