### PR TITLE
Revert "Update SCLo sync-up meeting time"

### DIFF
--- a/meetings/software-collections-sig-sync-up.yaml
+++ b/meetings/software-collections-sig-sync-up.yaml
@@ -2,7 +2,7 @@ project:  Software Collections SIG Sync-up
 project_url: http://wiki.centos.org/SpecialInterestGroup/SCLo
 meeting_id: SCLo SIG sync-up meeting
 schedule:
-  - time:       '1400'
+  - time:       '1300'
     day:        Tuesday
     irc:        centos-devel
     frequency:  biweekly-even


### PR DESCRIPTION
Reverts CentOS/Calendar#25

This new time conflicts with the Virtualization SIG.  @hhorak can you help me resolve this?