### PR TITLE
Updating meeting times for SCLo and Virt SIGs

### DIFF
--- a/meetings/software-collections-sig-sync-up.yaml
+++ b/meetings/software-collections-sig-sync-up.yaml
@@ -2,7 +2,7 @@ project:  Software Collections SIG Sync-up
 project_url: http://wiki.centos.org/SpecialInterestGroup/SCLo
 meeting_id: SCLo SIG sync-up meeting
 schedule:
-  - time:       '1300'
+  - time:       '1400'
     day:        Tuesday
     irc:        centos-devel
     frequency:  biweekly-even

--- a/meetings/virtualization-sig.yaml
+++ b/meetings/virtualization-sig.yaml
@@ -1,7 +1,7 @@
 project:  Virtualization SIG
 project_url: https://wiki.centos.org/SpecialInterestGroup/Virtualization
 schedule:
-  - time:       '1400'
+  - time:       '1500'
     day:        Tuesday
     irc:        centos-devel
     frequency:  biweekly-even


### PR DESCRIPTION
@bexelbie I've checked with @gwd and there is actually no conflict, Virt meeting is happening on hour after SCLo sig meeting.