### PR TITLE
All meetings have been moved to the #centos-meeting channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ will be import into Python as a dictionary.
         schedule:
             - time:       '1600'
               day:        Wednesday
-              irc:        centos-devel
+              irc:        centos-meeting
               frequency:  weekly
 
 * The chair is just a one liner. The might be left empty if there is not a

--- a/meetings/atomic-sig.yaml
+++ b/meetings/atomic-sig.yaml
@@ -3,7 +3,7 @@ project_url: http://wiki.centos.org/SpecialInterestGroup/Atomic
 schedule:
   - time:       '1600'
     day:        Thursday
-    irc:        centos-devel
+    irc:        centos-meeting
     frequency:  weekly
 chair:  Jason Brooks (jbrooks)
 description: >

--- a/meetings/cbs-infra.yaml
+++ b/meetings/cbs-infra.yaml
@@ -3,7 +3,7 @@ project_url: http://wiki.centos.org/HowTos/CommunityBuildSystem
 schedule:
     - time:      '1400'
       day:       Monday
-      irc:       centos-devel
+      irc:       centos-meeting
       frequency: weekly
 chair: Brian Stinson (bstinson), Fabian Arrotin (Arrfab), Karanbir Singh (kbsingh), Thomas Oulevey (alphacc)
 description: >

--- a/meetings/cloud-sig.yaml
+++ b/meetings/cloud-sig.yaml
@@ -3,7 +3,7 @@ project_url: http://wiki.centos.org/SpecialInterestGroup/Cloud
 schedule:
   - time:       '1500'
     day:        Thursday
-    irc:        centos-devel
+    irc:        centos-meeting
     frequency:  weekly
 chair: Rich Bowen (rbowen) and Kushal Das (kushal)
 description: |

--- a/meetings/config-management-sig.yaml
+++ b/meetings/config-management-sig.yaml
@@ -4,7 +4,7 @@ meeting_id: Config Management SIG regular meeting
 schedule:
   - time:       '1700'
     day:        Friday
-    irc:        centos-devel
+    irc:        centos-meeting
     frequency:  biweekly-even
 chair:  Julien Pivotto (roidelapluie)
 description: >

--- a/meetings/opstools-sig.yaml
+++ b/meetings/opstools-sig.yaml
@@ -3,7 +3,7 @@ project_url: http://wiki.centos.org/SpecialInterestGroup/OpsTools
 schedule:
   - time:       '1800'
     day:        Wednesday
-    irc:        centos-devel
+    irc:        centos-meeting
     frequency:  weekly
 chair: Matthias Runge (mrunge) and  Ric Megginson (richm)
 description: |

--- a/meetings/paas-sig.yaml
+++ b/meetings/paas-sig.yaml
@@ -3,7 +3,7 @@ project_url: https://wiki.centos.org/SpecialInterestGroup/PaaS
 schedule:
   - time:       '1700'
     day:        Wednesday
-    irc:        centos-devel
+    irc:        centos-meeting
     frequency:  weekly
 chair:  Troy Dawson (tdawson)
 description: >

--- a/meetings/software-collections-sig-sync-up.yaml
+++ b/meetings/software-collections-sig-sync-up.yaml
@@ -4,7 +4,7 @@ meeting_id: SCLo SIG sync-up meeting
 schedule:
   - time:       '1400'
     day:        Tuesday
-    irc:        centos-devel
+    irc:        centos-meeting
     frequency:  biweekly-even
 chair:  Honza Horak (hhorak)
 description: >

--- a/meetings/storage-sig.yaml
+++ b/meetings/storage-sig.yaml
@@ -3,7 +3,7 @@ project_url: http://wiki.centos.org/SpecialInterestGroup/Storage
 schedule:
   - time:       '1000'
     day:        Tuesday
-    irc:        centos-devel
+    irc:        centos-meeting
     frequency:  first-tuesday
 chair:  Karanbir Singh (kbsingh), Niels de Vos (ndevos), Giulio Fidente (gfidente)
 description: >

--- a/meetings/virtualization-sig.yaml
+++ b/meetings/virtualization-sig.yaml
@@ -3,7 +3,7 @@ project_url: https://wiki.centos.org/SpecialInterestGroup/Virtualization
 schedule:
   - time:       '1500'
     day:        Tuesday
-    irc:        centos-devel
+    irc:        centos-meeting
     frequency:  biweekly-even
 chair:  George Dunlap (gwd)
 description: >


### PR DESCRIPTION
This has been announced in May 2019 already [1]. The calendar was just
never updated.

1. https://lists.centos.org/pipermail/centos-announce/2019-May/023298.html