### PR TITLE
[Storage-Sig] Add the new agenda_url to the storage-sig meeting

### DIFF
--- a/meetings/storage-sig.yaml
+++ b/meetings/storage-sig.yaml
@@ -1,5 +1,6 @@
 project:  Storage SIG
 project_url: http://wiki.centos.org/SpecialInterestGroup/Storage
+agenda_url: https://hackmd.io/@qItv4l_CSAOOoigrY3dOGA/rkAGV6Lpr
 schedule:
   - time:       '1000'
     day:        Tuesday

--- a/output/calendar.md
+++ b/output/calendar.md
@@ -4,7 +4,7 @@
 
 The IRC meetings schedule is driven by the [github.com/CentOS/Calendar](https://github.com/CentOS/Calendar) repository.  To propose a change or add a meeting, please submit a pull-request to that git-hub repository.  This repository is mirrored to git.centos.org.
 
-Here is the link to a `.ical` file containing all CentOS IRC meetings, for use in your favorite calendaring app: [iCalendar Meeting Schedule](https://git.centos.org/raw/sig-core!calendar.git/master/output!irc-meetings.ical)
+Here is the link to a `.ical` file containing all CentOS IRC meetings, for use in your favorite calendaring app: [iCalendar Meeting Schedule](/community/irc-meetings.ical)
 
 A [list of all meetings](#list) is available below.
 
@@ -20,8 +20,6 @@ Here is a list of current meetings with their descriptions:
 * [Cloud SIG](#Cloud_SIG)
 * [Community Buildsystem & Infrastructure Meeting](#Community_Buildsystem_&_Infrastructure_Meeting)
 * [Config Management SIG](#Config_Management_SIG)
-* [Karanbir Singh Office Hours - Thursdays](#Karanbir_Singh_Office_Hours_-_Thursdays)
-* [Karanbir Singh Office Hours - Wednesdays](#Karanbir_Singh_Office_Hours_-_Wednesdays)
 * [OpsTools SIG](#OpsTools_SIG)
 * [PaaS SIG](#PaaS_SIG)
 * [Software Collections SIG Sync-up](#Software_Collections_SIG_Sync-up)
@@ -30,7 +28,7 @@ Here is a list of current meetings with their descriptions:
 
 ### <a name="Atomic_SIG">Atomic SIG</a>
 
-* Weekly on Thursday at [1600 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=16&amp;min=00&amp;sec=0) in #centos-devel
+* Weekly on Thursday at [1600 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=16&amp;min=00&amp;sec=0) in #centos-meeting
 * Chair (to contact for more information): Jason Brooks (jbrooks)
 * [Link to Project Site](http://wiki.centos.org/SpecialInterestGroup/Atomic)
 * The SIG is working on several goals including shipping a minimal CentOS Atomic Host that focuses on running Docker containers in production.
@@ -38,8 +36,8 @@ Here is a list of current meetings with their descriptions:
 
 ### <a name="Cloud_SIG">Cloud SIG</a>
 
-* Weekly on Thursday at [1500 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=15&amp;min=00&amp;sec=0) in #centos-devel
-* Chair (to contact for more information): Rich Bowen (rbowen) and Kushal Das (kushal)
+* Weekly on Thursday at [1500 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=15&amp;min=00&amp;sec=0) in #centos-meeting
+* Chair (to contact for more information): Rain Leander (leanderthal) and Kushal Das (kushal)
 * [Link to Project Site](http://wiki.centos.org/SpecialInterestGroup/Cloud)
 * The proposed CentOS Cloud SIG (CCS) is a group of people coming together to focus on packaging and maintaining different FOSS based Private cloud infrastructure applications that one can install and run natively on CentOS. We are a non vendor, non technology and non agent specific focus group, but we will gladly work with and build content to suit relevant niches or vendor ecosystems. This group specifically targets users who wish to install and run their own, independent ( or hybrid ) cloud infrastructure on CentOS Linux.
 
@@ -48,7 +46,7 @@ The CCS intends to take ownership of existing CentOS Project relationships with 
 
 ### <a name="Community_Buildsystem_&_Infrastructure_Meeting">Community Buildsystem & Infrastructure Meeting</a>
 
-* Weekly on Monday at [1400 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=14&amp;min=00&amp;sec=0) in #centos-devel
+* Weekly on Monday at [1400 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=14&amp;min=00&amp;sec=0) in #centos-meeting
 * Chair (to contact for more information): Brian Stinson (bstinson), Fabian Arrotin (Arrfab), Karanbir Singh (kbsingh), Thomas Oulevey (alphacc)
 * [Link to Project Site](http://wiki.centos.org/HowTos/CommunityBuildSystem)
 * The CBS/Infra meeting is for discussing and coordinating operations in the Community Buildsystem. Anyone are welcome to attend and discuss client tools, jobs in the buildsystem, feature requests, and anything related.
@@ -56,39 +54,15 @@ The CCS intends to take ownership of existing CentOS Project relationships with 
 
 ### <a name="Config_Management_SIG">Config Management SIG</a>
 
-* Every two weeks (on even weeks) on Friday at [1700 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=17&amp;min=00&amp;sec=0) in #centos-devel
+* Every two weeks (on even weeks) on Friday at [1700 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=17&amp;min=00&amp;sec=0) in #centos-meeting
 * Chair (to contact for more information): Julien Pivotto (roidelapluie)
 * [Link to Project Site](https://wiki.centos.org/SpecialInterestGroup/ConfigManagementSIG)
 * The Config Management SIG is a SpecialInterestGroup that aims to bridge the gap between Config Management tools Power users and traditional users by producing and release RPM packages of several Configuration Management and Orchestration tools.
 
 
-### <a name="Karanbir_Singh_Office_Hours_-_Thursdays">Karanbir Singh Office Hours - Thursdays</a>
-
-* Weekly on Thursday at [0930 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=09&amp;min=30&amp;sec=0) in #centos-devel
-* Chair (to contact for more information): Karanbir Singh (kbsingh)
-* [Link to Project Site](http://www.karan.org/blog/2015/06/08/regular-office-hours/)
-* I am going to make myself available to anyone who wants to come along and
-talk about CentOS Linux, the CentOS Project, the SIGs or anything else that
-is related to these.  During this time, you can find me on #centos-devel @
-<a href="http://irc.freenode.net" rel="noopener">irc.freenode.net</a> as kbsingh, and you can also call me on the phone
-at +44 207 009 4455.
-
-
-### <a name="Karanbir_Singh_Office_Hours_-_Wednesdays">Karanbir Singh Office Hours - Wednesdays</a>
-
-* Weekly on Wednesday at [1700 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=17&amp;min=00&amp;sec=0) in #centos-devel via PM
-* Chair (to contact for more information): Karanbir Singh (kbsingh)
-* [Link to Project Site](http://www.karan.org/blog/2015/06/08/regular-office-hours/)
-* I am going to make myself available to anyone who wants to come along and
-talk about CentOS Linux, the CentOS Project, the SIGs or anything else that
-is related to these.  During this time, you can find me on #centos-devel @
-<a href="http://irc.freenode.net" rel="noopener">irc.freenode.net</a> as kbsingh, and you can also call me on the phone
-at +44 207 009 4455.
-
-
 ### <a name="OpsTools_SIG">OpsTools SIG</a>
 
-* Weekly on Wednesday at [1800 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=18&amp;min=00&amp;sec=0) in #centos-devel
+* Weekly on Wednesday at [1800 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=18&amp;min=00&amp;sec=0) in #centos-meeting
 * Chair (to contact for more information): Matthias Runge (mrunge) and  Ric Megginson (richm)
 * [Link to Project Site](http://wiki.centos.org/SpecialInterestGroup/OpsTools)
 * The SIG will provide tools for operators, system administrators, devops and developers doing infrastructure engineering on content based on CentOS Linux. We will aim to support the Config Management SIG ( <a href="https://wiki.centos.org/SpecialInterestGroup/ConfigManagementSIG" rel="noopener">https://wiki.centos.org/SpecialInterestGroup/ConfigManagementSIG</a> ) and repurpose their content as and when needed in our space.
@@ -96,7 +70,7 @@ at +44 207 009 4455.
 
 ### <a name="PaaS_SIG">PaaS SIG</a>
 
-* Weekly on Wednesday at [1700 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=17&amp;min=00&amp;sec=0) in #centos-devel
+* Weekly on Wednesday at [1700 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=17&amp;min=00&amp;sec=0) in #centos-meeting
 * Chair (to contact for more information): Troy Dawson (tdawson)
 * [Link to Project Site](https://wiki.centos.org/SpecialInterestGroup/PaaS)
 * The SIG will work on delivering multiple PaaS Stacks. These stacks will come in various formats (rpms, containers, images etc ) The content will be delivered into the CentOS Ecosystem for end user consumption, run as a service, and support other CentOS Ecosystem projects.
@@ -104,7 +78,7 @@ at +44 207 009 4455.
 
 ### <a name="Software_Collections_SIG_Sync-up">Software Collections SIG Sync-up</a>
 
-* Every two weeks (on even weeks) on Tuesday at [1400 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=14&amp;min=00&amp;sec=0) in #centos-devel
+* Every two weeks (on even weeks) on Tuesday at [1400 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=14&amp;min=00&amp;sec=0) in #centos-meeting
 * Chair (to contact for more information): Honza Horak (hhorak)
 * [Link to Project Site](http://wiki.centos.org/SpecialInterestGroup/SCLo)
 * The Software Collections SIG will provide an upstream development area for various software collections and related tools. Developers can build on and extend existing SCLs, so they don&#39;t need to re-invent the wheel or take responsibility for packaging unnecessary dependencies. 
@@ -112,19 +86,20 @@ at +44 207 009 4455.
 
 ### <a name="Storage_SIG">Storage SIG</a>
 
-* Monthly on Tuesday at [1000 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=10&amp;min=00&amp;sec=0) in #centos-devel
+* Monthly on Tuesday at [1000 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=10&amp;min=00&amp;sec=0) in #centos-meeting
 * Chair (to contact for more information): Karanbir Singh (kbsingh), Niels de Vos (ndevos), Giulio Fidente (gfidente)
 * [Link to Project Site](http://wiki.centos.org/SpecialInterestGroup/Storage)
 * The CentOS Storage Special Interest Group (SIG) is a collection of like-minded individuals coming together to ensure that CentOS is a suitable platform for many different storage solutions. This group will ensure that all Open Source storage options seeking to utilize CentOS as a delivery platform have a voice in packaging, orchestration, deployment, and related work. 
 
+* [Link to Agenda](https://hackmd.io/@qItv4l_CSAOOoigrY3dOGA/rkAGV6Lpr)
 
 ### <a name="Virtualization_SIG">Virtualization SIG</a>
 
-* Every two weeks (on even weeks) on Tuesday at [1500 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=15&amp;min=00&amp;sec=0) in #centos-devel
+* Every two weeks (on even weeks) on Tuesday at [1500 UTC](http://www.timeanddate.com/worldclock/fixedtime.html?hour=15&amp;min=00&amp;sec=0) in #centos-meeting
 * Chair (to contact for more information): George Dunlap (gwd)
 * [Link to Project Site](https://wiki.centos.org/SpecialInterestGroup/Virtualization)
 * The CentOS Virtualisation Special Interest Group ( virt-sig ) is a group of people coming together to promote and use CentOS Linux as a base platform as a suitable platform for various virtualisation efforts. This includes type-1 and type-2 hypervisors like Xen and KVM, containers and containment based technologies like LXC and other system and process level virtualisation technologies in the future.
 
 
 
-Page generated on 2019-10-08 08:43:28.322965 UTC
+Page generated on 2020-03-29 09:24:30.654702 UTC

--- a/output/irc-meetings.ical
+++ b/output/irc-meetings.ical
@@ -5,37 +5,38 @@ X-WR-CALDESC:Meeting schedule for the CentOS Project and SIGS
 X-WR-CALNAME:CentOS Meetings
 BEGIN:VEVENT
 SUMMARY:Atomic SIG
-DTSTART;VALUE=DATE-TIME:20191010T160000Z
+DTSTART;VALUE=DATE-TIME:20200402T160000Z
 DURATION:PT1H
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  Atomic SIG\nChair:  Jason Brooks (jbrooks)\nDescript
  ion:  The SIG is working on several goals including shipping a minimal Cen
  tOS Atomic Host that focuses on running Docker containers in production.\n
  \nProject URL:  http://wiki.centos.org/SpecialInterestGroup/Atomic
-LOCATION:#centos-devel
+LOCATION:#centos-meeting
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Cloud SIG
-DTSTART;VALUE=DATE-TIME:20191010T150000Z
+DTSTART;VALUE=DATE-TIME:20200402T150000Z
 DURATION:PT1H
 RRULE:FREQ=WEEKLY
-DESCRIPTION:Project:  Cloud SIG\nChair:  Rich Bowen (rbowen) and Kushal Da
- s (kushal)\nDescription:  The proposed CentOS Cloud SIG (CCS) is a group o
- f people coming together to focus on packaging and maintaining different F
- OSS based Private cloud infrastructure applications that one can install a
- nd run natively on CentOS. We are a non vendor\, non technology and non ag
- ent specific focus group\, but we will gladly work with and build content 
- to suit relevant niches or vendor ecosystems. This group specifically targ
- ets users who wish to install and run their own\, independent ( or hybrid 
- ) cloud infrastructure on CentOS Linux.\n\nThe CCS intends to take ownersh
- ip of existing CentOS Project relationships with vendors\, and help to mai
- ntain the updated package repositories for all participating cloud project
- s. \n\nProject URL:  http://wiki.centos.org/SpecialInterestGroup/Cloud
-LOCATION:#centos-devel
+DESCRIPTION:Project:  Cloud SIG\nChair:  Rain Leander (leanderthal) and Ku
+ shal Das (kushal)\nDescription:  The proposed CentOS Cloud SIG (CCS) is a 
+ group of people coming together to focus on packaging and maintaining diff
+ erent FOSS based Private cloud infrastructure applications that one can in
+ stall and run natively on CentOS. We are a non vendor\, non technology and
+  non agent specific focus group\, but we will gladly work with and build c
+ ontent to suit relevant niches or vendor ecosystems. This group specifical
+ ly targets users who wish to install and run their own\, independent ( or 
+ hybrid ) cloud infrastructure on CentOS Linux.\n\nThe CCS intends to take 
+ ownership of existing CentOS Project relationships with vendors\, and help
+  to maintain the updated package repositories for all participating cloud 
+ projects. \n\nProject URL:  http://wiki.centos.org/SpecialInterestGroup/Cl
+ oud
+LOCATION:#centos-meeting
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Community Buildsystem & Infrastructure Meeting
-DTSTART;VALUE=DATE-TIME:20191014T140000Z
+DTSTART;VALUE=DATE-TIME:20200330T140000Z
 DURATION:PT1H
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  Community Buildsystem & Infrastructure Meeting\nChai
@@ -45,11 +46,11 @@ DESCRIPTION:Project:  Community Buildsystem & Infrastructure Meeting\nChai
  Anyone are welcome to attend and discuss client tools\, jobs in the builds
  ystem\, feature requests\, and anything related.\n\nProject URL:  http://w
  iki.centos.org/HowTos/CommunityBuildSystem
-LOCATION:#centos-devel
+LOCATION:#centos-meeting
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Config Management SIG
-DTSTART;VALUE=DATE-TIME:20191018T170000Z
+DTSTART;VALUE=DATE-TIME:20200403T170000Z
 DURATION:PT1H
 RRULE:FREQ=WEEKLY;INTERVAL=2
 DESCRIPTION:Project:  Config Management SIG\nChair:  Julien Pivotto (roide
@@ -58,39 +59,11 @@ DESCRIPTION:Project:  Config Management SIG\nChair:  Julien Pivotto (roide
  and traditional users by producing and release RPM packages of several Con
  figuration Management and Orchestration tools.\n\nProject URL:  https://wi
  ki.centos.org/SpecialInterestGroup/ConfigManagementSIG
-LOCATION:#centos-devel
-END:VEVENT
-BEGIN:VEVENT
-SUMMARY:Karanbir Singh Office Hours - Thursdays
-DTSTART;VALUE=DATE-TIME:20191010T093000Z
-DURATION:PT30M
-RRULE:FREQ=WEEKLY
-DESCRIPTION:Project:  Karanbir Singh Office Hours - Thursdays\nChair:  Kar
- anbir Singh (kbsingh)\nDescription:  I am going to make myself available t
- o anyone who wants to come along and\ntalk about CentOS Linux\, the CentOS
-  Project\, the SIGs or anything else that\nis related to these.  During th
- is time\, you can find me on #centos-devel @\nirc.freenode.net as kbsingh\
- , and you can also call me on the phone\nat +44 207 009 4455.\n\nProject U
- RL:  http://www.karan.org/blog/2015/06/08/regular-office-hours/
-LOCATION:#centos-devel
-END:VEVENT
-BEGIN:VEVENT
-SUMMARY:Karanbir Singh Office Hours - Wednesdays
-DTSTART;VALUE=DATE-TIME:20191009T170000Z
-DURATION:PT30M
-RRULE:FREQ=WEEKLY
-DESCRIPTION:Project:  Karanbir Singh Office Hours - Wednesdays\nChair:  Ka
- ranbir Singh (kbsingh)\nDescription:  I am going to make myself available 
- to anyone who wants to come along and\ntalk about CentOS Linux\, the CentO
- S Project\, the SIGs or anything else that\nis related to these.  During t
- his time\, you can find me on #centos-devel @\nirc.freenode.net as kbsingh
- \, and you can also call me on the phone\nat +44 207 009 4455.\n\nProject 
- URL:  http://www.karan.org/blog/2015/06/08/regular-office-hours/
-LOCATION:#centos-devel via PM
+LOCATION:#centos-meeting
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:OpsTools SIG
-DTSTART;VALUE=DATE-TIME:20191009T180000Z
+DTSTART;VALUE=DATE-TIME:20200401T180000Z
 DURATION:PT1H
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  OpsTools SIG\nChair:  Matthias Runge (mrunge) and  R
@@ -100,11 +73,11 @@ DESCRIPTION:Project:  OpsTools SIG\nChair:  Matthias Runge (mrunge) and  R
  fig Management SIG ( https://wiki.centos.org/SpecialInterestGroup/ConfigMa
  nagementSIG ) and repurpose their content as and when needed in our space.
  \n\nProject URL:  http://wiki.centos.org/SpecialInterestGroup/OpsTools
-LOCATION:#centos-devel
+LOCATION:#centos-meeting
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:PaaS SIG
-DTSTART;VALUE=DATE-TIME:20191009T170000Z
+DTSTART;VALUE=DATE-TIME:20200401T170000Z
 DURATION:PT1H
 RRULE:FREQ=WEEKLY
 DESCRIPTION:Project:  PaaS SIG\nChair:  Troy Dawson (tdawson)\nDescription
@@ -113,11 +86,11 @@ DESCRIPTION:Project:  PaaS SIG\nChair:  Troy Dawson (tdawson)\nDescription
  l be delivered into the CentOS Ecosystem for end user consumption\, run as
   a service\, and support other CentOS Ecosystem projects.\n\nProject URL: 
   https://wiki.centos.org/SpecialInterestGroup/PaaS
-LOCATION:#centos-devel
+LOCATION:#centos-meeting
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Software Collections SIG Sync-up
-DTSTART;VALUE=DATE-TIME:20191015T140000Z
+DTSTART;VALUE=DATE-TIME:20200331T140000Z
 DURATION:PT1H
 RRULE:FREQ=WEEKLY;INTERVAL=2
 DESCRIPTION:Project:  Software Collections SIG Sync-up\nChair:  Honza Hora
@@ -127,11 +100,11 @@ DESCRIPTION:Project:  Software Collections SIG Sync-up\nChair:  Honza Hora
  re-invent the wheel or take responsibility for packaging unnecessary depen
  dencies. \n\nProject URL:  http://wiki.centos.org/SpecialInterestGroup/SCL
  o
-LOCATION:#centos-devel
+LOCATION:#centos-meeting
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Storage SIG
-DTSTART;VALUE=DATE-TIME:20191105T100000Z
+DTSTART;VALUE=DATE-TIME:20200407T100000Z
 DURATION:PT1H
 RRULE:FREQ=MONTHLY;BYDAY=1TU
 DESCRIPTION:Project:  Storage SIG\nChair:  Karanbir Singh (kbsingh)\, Niel
@@ -140,13 +113,14 @@ DESCRIPTION:Project:  Storage SIG\nChair:  Karanbir Singh (kbsingh)\, Niel
  als coming together to ensure that CentOS is a suitable platform for many 
  different storage solutions. This group will ensure that all Open Source s
  torage options seeking to utilize CentOS as a delivery platform have a voi
- ce in packaging\, orchestration\, deployment\, and related work. \n\nProje
- ct URL:  http://wiki.centos.org/SpecialInterestGroup/Storage
-LOCATION:#centos-devel
+ ce in packaging\, orchestration\, deployment\, and related work. \n\nAgend
+ a URL:  https://hackmd.io/@qItv4l_CSAOOoigrY3dOGA/rkAGV6Lpr\nProject URL: 
+  http://wiki.centos.org/SpecialInterestGroup/Storage
+LOCATION:#centos-meeting
 END:VEVENT
 BEGIN:VEVENT
 SUMMARY:Virtualization SIG
-DTSTART;VALUE=DATE-TIME:20191015T150000Z
+DTSTART;VALUE=DATE-TIME:20200331T150000Z
 DURATION:PT1H
 RRULE:FREQ=WEEKLY;INTERVAL=2
 DESCRIPTION:Project:  Virtualization SIG\nChair:  George Dunlap (gwd)\nDes
@@ -157,6 +131,6 @@ DESCRIPTION:Project:  Virtualization SIG\nChair:  George Dunlap (gwd)\nDes
  d containment based technologies like LXC and other system and process lev
  el virtualisation technologies in the future.\n\nProject URL:  https://wik
  i.centos.org/SpecialInterestGroup/Virtualization
-LOCATION:#centos-devel
+LOCATION:#centos-meeting
 END:VEVENT
 END:VCALENDAR


### PR DESCRIPTION
This change just adds the new agenda_url to the storage-sig
meeting file and regenerates the output (calendar and irc
meetings) according to the new info.

Signed-off-by: Francesco Pantano <fpantano@redhat.com>