### PR TITLE
Virt SIG: Change to Wednesdays 1600UTC

### DIFF
--- a/meetings/virtualization-sig.yaml
+++ b/meetings/virtualization-sig.yaml
@@ -1,8 +1,8 @@
 project:  Virtualization SIG
 project_url: https://wiki.centos.org/SpecialInterestGroup/Virtualization
 schedule:
-  - time:       '1500'
-    day:        Tuesday
+  - time:       '1600'
+    day:        Wednesday
     irc:        centos-meeting
     frequency:  biweekly-even
 chair:  George Dunlap (gwd)


### PR DESCRIPTION
Looks like we were meeting on the wrong-numbered week; this week is week 13, so if we switch to next week, "biweekly-even" is still the right frequency.

Signed-off-by: George Dunlap <george.dunlap@citrix.com>
@sandrobonazzola 
