### PR TITLE
Add the Hyperscale SIG to the calendar

### DIFF
--- a/meetings/hyperscale-sig.yaml
+++ b/meetings/hyperscale-sig.yaml
@@ -1,0 +1,10 @@
+project:  Hyperscale SIG
+project_url: https://wiki.centos.org/SpecialInterestGroup/Hyperscale
+schedule:
+  - time:       '1800'
+    day:        Wednesday
+    irc:        centos-meeting
+    frequency:  biweekly-odd
+chair: Davide Cavalca (dcavalca) and Justin Vreeland (jvreeland)
+description: |
+    The Hyperscale SIG focuses on enabling CentOS Stream deployment on large-scale infrastructures and facilitating collaboration on packages and tooling.


### PR DESCRIPTION
Add regular meeting for the Hyperscale SIG. We originally wanted to do this on the third Wed of the month, but that doesn't seem to be an option in the tool, so let's go with biweekly for now (with the idea that Feb 17 would be the first one).