### PR TITLE
Update Kmods SIG meeting time

### DIFF
--- a/meetings/kmods-sig.yaml
+++ b/meetings/kmods-sig.yaml
@@ -1,7 +1,7 @@
 project:  Kmods SIG
 project_url: https://wiki.centos.org/SpecialInterestGroup/Kmods
 schedule:
-  - time:       '1500'
+  - time:       '1600'
     day:        Monday
     irc:        centos-meeting
     frequency:  biweekly-even

--- a/meetings/kmods-sig.yaml
+++ b/meetings/kmods-sig.yaml
@@ -7,4 +7,4 @@ schedule:
     frequency:  biweekly-even
 chair: Peter Georg (pjgeorg) and Jonathan Billings (billings)
 description: |
-    The kmods SIG focuses on providing kernel modules currently not available in CentOS Stream.
+    The kmods SIG focuses on providing kernel modules currently not available in Enterprise Linux.


### PR DESCRIPTION
The Kmods SIG is shifting the meeting time from 1500UTC to 1600UTC.

This is mainly due to conflicts with members' working meetings caused by the last DST change. Most members have their other meetings scheduled in local time, i.e. only the Kmods SIG's meeting's time has been changed in local time and caused conflicts.

Is there any way to specify a time that depends on DST? Otherwise we'll probably end up changing the time every half year.


While at it I also replaced the description. The Kmods SIG now also provides kernel modules for EL8 and it is also planned for EL9 once available. Replace CentOS Stream by Enterprise Linux to be more generic and cover CentOS Stream, RHEL, Rocky, etc.

[logs]: https://www.centos.org/minutes/2021/November/centos-meeting.2021-11-29-15.02.html