### PR TITLE
Update Kmods SIG regular  meeting

### DIFF
--- a/meetings/kmods-sig.yaml
+++ b/meetings/kmods-sig.yaml
@@ -1,5 +1,5 @@
 project:  Kmods SIG
-project_url: https://wiki.centos.org/SpecialInterestGroup/Kmods
+project_url: https://sigs.centos.org/kmods
 schedule:
   - time:       '1600'
     day:        Monday

--- a/meetings/kmods-sig.yaml
+++ b/meetings/kmods-sig.yaml
@@ -4,7 +4,7 @@ schedule:
   - time:       '1600'
     day:        Monday
     irc:        centos-meeting
-    frequency:  biweekly-even
+    frequency:  first-monday
 chair: Peter Georg (pjgeorg)
 description: |
     The kmods SIG focuses on providing kernel modules currently not available in Enterprise Linux.

--- a/meetings/kmods-sig.yaml
+++ b/meetings/kmods-sig.yaml
@@ -5,6 +5,6 @@ schedule:
     day:        Monday
     irc:        centos-meeting
     frequency:  biweekly-even
-chair: Peter Georg (pjgeorg) and Jonathan Billings (billings)
+chair: Peter Georg (pjgeorg)
 description: |
     The kmods SIG focuses on providing kernel modules currently not available in Enterprise Linux.


### PR DESCRIPTION
In today's kmods SIG meeting it has been decided to change the frequency of the regular meeting to first Monday of each month.

While changing this I also updated the current Kmods SIG chairs and chhanged the project_url.
We use https://sigs.centos.org/kmods for our user facing and internal documentation.