### PR TITLE
altimages once a month

### DIFF
--- a/meetings/altimages-sig.yaml
+++ b/meetings/altimages-sig.yaml
@@ -4,7 +4,7 @@ schedule:
   - time:       '1900'
     day:        Thursday
     irc:        centos-meeting
-    frequency:  biweekly-even
+    frequency: second-thursday
 chair: Troy Dawson (tdawson)
 description: |
     The Alternate Images SIG's goal is to build and provide alternate iso images for CentOS Stream


### PR DESCRIPTION
altimages is changing their meeting pace to once a month on the second thursday of each month.