### PR TITLE
Have an extra calendar entry for Hyperscale SIG hangout for DST

### DIFF
--- a/meetings/hyperscale-sig-hangout-dst.yaml
+++ b/meetings/hyperscale-sig-hangout-dst.yaml
@@ -1,7 +1,7 @@
-project:  Hyperscale SIG monthly hangout (US standard time)
+project:  Hyperscale SIG monthly hangout (US daylight saving time)
 project_url: https://sigs.centos.org/hyperscale/
 schedule:
-  - time:       '2200'
+  - time:       '2100'
     day:        Wednesday
     irc:        zoom-vc
     frequency:  third-wednesday


### PR DESCRIPTION
Since the calendaring system assumes all meetings are UTC and this meeting is actually pinned to US time, let's have a separate meeting entry showing when it happens when DST is in effect in the US rather than having to keep putting up PRs and trying to get them merged every 6 months (or giving up, as we have been for the past few months)